### PR TITLE
feat: Repository management interface with filtering, sorting, and CRUD operations

### DIFF
--- a/frontend/src/pages/RepositoriesPage.tsx
+++ b/frontend/src/pages/RepositoriesPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { GitBranch, Database, Server, ExternalLink, Play, Webhook, Copy, Check } from 'lucide-react'
+import { GitBranch, Database, Server, ExternalLink, Play, Webhook, Copy, Check, Filter, ArrowUpDown, Eye, Edit2, Trash2 } from 'lucide-react'
 import logger from '../lib/logger'
 import AddRepositoryModal from '../components/AddRepositoryModal'
 
@@ -40,6 +40,24 @@ export default function RepositoriesPage() {
   const [selectedRepo, setSelectedRepo] = useState<Repository | null>(null)
   const [webhookSecret, setWebhookSecret] = useState<string | null>(null)
   const [copied, setCopied] = useState<'secret' | 'url' | null>(null)
+
+  // Filtering and sorting
+  const [typeFilter, setTypeFilter] = useState<'all' | 'git' | 'database' | 'mainframe'>('all')
+  const [sortBy, setSortBy] = useState<'created_at' | 'last_scan_at' | 'name'>('created_at')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc')
+
+  // Details modal
+  const [detailsModalOpen, setDetailsModalOpen] = useState(false)
+  const [detailsRepo, setDetailsRepo] = useState<Repository | null>(null)
+  const [scanHistory, setScanHistory] = useState<ScanProgress[]>([])
+
+  // Edit modal
+  const [editModalOpen, setEditModalOpen] = useState(false)
+  const [editRepo, setEditRepo] = useState<Repository | null>(null)
+
+  // Delete confirmation
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false)
+  const [deleteRepo, setDeleteRepo] = useState<Repository | null>(null)
 
   const fetchRepositories = async () => {
     try {
@@ -207,6 +225,116 @@ export default function RepositoriesPage() {
     }
   }
 
+  const handleViewDetails = async (repo: Repository) => {
+    setDetailsRepo(repo)
+    setDetailsModalOpen(true)
+
+    // Fetch scan history
+    try {
+      const response = await fetch(`/api/v1/repositories/${repo.id}/scans`)
+      if (response.ok) {
+        const scans = await response.json()
+        setScanHistory(scans)
+      }
+    } catch (err) {
+      logger.error('Failed to fetch scan history', { error: err })
+    }
+  }
+
+  const handleEdit = (repo: Repository) => {
+    setEditRepo(repo)
+    setEditModalOpen(true)
+  }
+
+  const handleSaveEdit = async () => {
+    if (!editRepo) return
+
+    try {
+      const response = await fetch(`/api/v1/repositories/${editRepo.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: editRepo.name,
+          description: editRepo.description,
+        }),
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to update repository')
+      }
+
+      await fetchRepositories()
+      setEditModalOpen(false)
+      setEditRepo(null)
+      logger.info('Repository updated', { repositoryId: editRepo.id })
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
+      logger.error('Failed to update repository', { error: errorMessage })
+      alert(`Failed to update repository: ${errorMessage}`)
+    }
+  }
+
+  const handleDelete = (repo: Repository) => {
+    setDeleteRepo(repo)
+    setDeleteModalOpen(true)
+  }
+
+  const handleConfirmDelete = async () => {
+    if (!deleteRepo) return
+
+    try {
+      const response = await fetch(`/api/v1/repositories/${deleteRepo.id}`, {
+        method: 'DELETE',
+      })
+
+      if (!response.ok) {
+        throw new Error('Failed to delete repository')
+      }
+
+      await fetchRepositories()
+      setDeleteModalOpen(false)
+      setDeleteRepo(null)
+      logger.info('Repository deleted', { repositoryId: deleteRepo.id })
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred'
+      logger.error('Failed to delete repository', { error: errorMessage })
+      alert(`Failed to delete repository: ${errorMessage}`)
+    }
+  }
+
+  // Filter and sort repositories
+  const filteredAndSortedRepositories = repositories
+    .filter((repo) => {
+      if (typeFilter === 'all') return true
+      return repo.repository_type === typeFilter
+    })
+    .sort((a, b) => {
+      let aValue: string | number | null
+      let bValue: string | number | null
+
+      if (sortBy === 'name') {
+        aValue = a.name
+        bValue = b.name
+      } else if (sortBy === 'last_scan_at') {
+        aValue = a.last_scan_at || ''
+        bValue = b.last_scan_at || ''
+      } else {
+        aValue = a.created_at
+        bValue = b.created_at
+      }
+
+      if (aValue === null || aValue === '') return sortOrder === 'asc' ? -1 : 1
+      if (bValue === null || bValue === '') return sortOrder === 'asc' ? 1 : -1
+
+      if (sortOrder === 'asc') {
+        return aValue > bValue ? 1 : -1
+      } else {
+        return aValue < bValue ? 1 : -1
+      }
+    })
+
   const getTypeIcon = (type: string) => {
     switch (type) {
       case 'git':
@@ -247,6 +375,48 @@ export default function RepositoriesPage() {
         </button>
       </div>
 
+      {/* Filters and Sorting */}
+      <div className="flex items-center space-x-4 border border-gray-200 dark:border-dark-border rounded-lg bg-white dark:bg-dark-surface p-4">
+        <div className="flex items-center space-x-2">
+          <Filter size={16} className="text-gray-600 dark:text-gray-400" />
+          <span className="text-sm font-medium">Filter:</span>
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value as 'all' | 'git' | 'database' | 'mainframe')}
+            className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-sm"
+          >
+            <option value="all">All Types</option>
+            <option value="git">Git</option>
+            <option value="database">Database</option>
+            <option value="mainframe">Mainframe</option>
+          </select>
+        </div>
+
+        <div className="flex items-center space-x-2">
+          <ArrowUpDown size={16} className="text-gray-600 dark:text-gray-400" />
+          <span className="text-sm font-medium">Sort by:</span>
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as 'created_at' | 'last_scan_at' | 'name')}
+            className="px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-sm"
+          >
+            <option value="created_at">Date Added</option>
+            <option value="last_scan_at">Last Scan</option>
+            <option value="name">Name</option>
+          </select>
+          <button
+            onClick={() => setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc')}
+            className="px-2 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 text-sm"
+          >
+            {sortOrder === 'asc' ? '↑' : '↓'}
+          </button>
+        </div>
+
+        <div className="text-sm text-gray-600 dark:text-dark-text-secondary ml-auto">
+          {filteredAndSortedRepositories.length} of {repositories.length} repositories
+        </div>
+      </div>
+
       {error && (
         <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-red-800 dark:text-red-200">
           {error}
@@ -257,15 +427,15 @@ export default function RepositoriesPage() {
         <div className="border border-gray-200 dark:border-dark-border rounded-lg bg-white dark:bg-dark-surface p-8 text-center">
           <p className="text-gray-600 dark:text-dark-text-secondary">Loading repositories...</p>
         </div>
-      ) : repositories.length === 0 ? (
+      ) : filteredAndSortedRepositories.length === 0 ? (
         <div className="border border-gray-200 dark:border-dark-border rounded-lg bg-white dark:bg-dark-surface p-8 text-center">
           <p className="text-gray-600 dark:text-dark-text-secondary">
-            No repositories yet. Click "Add Repository" to get started.
+            {repositories.length === 0 ? 'No repositories yet. Click "Add Repository" to get started.' : 'No repositories match the current filter.'}
           </p>
         </div>
       ) : (
         <div className="grid gap-4">
-          {repositories.map((repo) => (
+          {filteredAndSortedRepositories.map((repo) => (
             <div
               key={repo.id}
               className="border border-gray-200 dark:border-dark-border rounded-lg bg-white dark:bg-dark-surface p-6 hover:shadow-md transition"
@@ -306,8 +476,29 @@ export default function RepositoriesPage() {
                     </div>
                   </div>
                 </div>
-                <div className="flex items-center space-x-3">
+                <div className="flex items-center space-x-2">
                   {getStatusBadge(repo.status)}
+                  <button
+                    onClick={() => handleViewDetails(repo)}
+                    className="inline-flex items-center space-x-1 px-2 py-1.5 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 text-sm"
+                    title="View details"
+                  >
+                    <Eye size={16} />
+                  </button>
+                  <button
+                    onClick={() => handleEdit(repo)}
+                    className="inline-flex items-center space-x-1 px-2 py-1.5 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 text-sm"
+                    title="Edit repository"
+                  >
+                    <Edit2 size={16} />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(repo)}
+                    className="inline-flex items-center space-x-1 px-2 py-1.5 border border-red-300 dark:border-red-600 text-red-700 dark:text-red-400 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 text-sm"
+                    title="Delete repository"
+                  >
+                    <Trash2 size={16} />
+                  </button>
                   {repo.repository_type === 'git' && repo.status === 'connected' && (
                     <>
                       <button
@@ -485,6 +676,235 @@ export default function RepositoriesPage() {
                 className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600"
               >
                 Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Details Modal */}
+      {detailsModalOpen && detailsRepo && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-dark-surface rounded-lg shadow-xl max-w-4xl w-full mx-4 p-6 max-h-[90vh] overflow-y-auto">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-xl font-semibold">Repository Details</h3>
+              <button
+                onClick={() => {
+                  setDetailsModalOpen(false)
+                  setDetailsRepo(null)
+                  setScanHistory([])
+                }}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="space-y-6">
+              {/* Basic Info */}
+              <div className="border border-gray-200 dark:border-dark-border rounded-lg p-4">
+                <h4 className="font-medium mb-3">Basic Information</h4>
+                <div className="grid grid-cols-2 gap-4 text-sm">
+                  <div>
+                    <span className="text-gray-600 dark:text-dark-text-secondary">Name:</span>
+                    <p className="font-medium mt-1">{detailsRepo.name}</p>
+                  </div>
+                  <div>
+                    <span className="text-gray-600 dark:text-dark-text-secondary">Type:</span>
+                    <p className="font-medium mt-1 capitalize">{detailsRepo.repository_type}</p>
+                  </div>
+                  <div>
+                    <span className="text-gray-600 dark:text-dark-text-secondary">Status:</span>
+                    <div className="mt-1">{getStatusBadge(detailsRepo.status)}</div>
+                  </div>
+                  <div>
+                    <span className="text-gray-600 dark:text-dark-text-secondary">Created:</span>
+                    <p className="font-medium mt-1">{new Date(detailsRepo.created_at).toLocaleString()}</p>
+                  </div>
+                  {detailsRepo.description && (
+                    <div className="col-span-2">
+                      <span className="text-gray-600 dark:text-dark-text-secondary">Description:</span>
+                      <p className="font-medium mt-1">{detailsRepo.description}</p>
+                    </div>
+                  )}
+                  {detailsRepo.source_url && (
+                    <div className="col-span-2">
+                      <span className="text-gray-600 dark:text-dark-text-secondary">Source URL:</span>
+                      <a
+                        href={detailsRepo.source_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center space-x-1 text-blue-600 dark:text-blue-400 hover:underline mt-1"
+                      >
+                        <span>{detailsRepo.source_url}</span>
+                        <ExternalLink size={14} />
+                      </a>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Scan History */}
+              <div className="border border-gray-200 dark:border-dark-border rounded-lg p-4">
+                <h4 className="font-medium mb-3">Scan History</h4>
+                {scanHistory.length === 0 ? (
+                  <p className="text-sm text-gray-600 dark:text-dark-text-secondary">No scans yet</p>
+                ) : (
+                  <div className="space-y-2">
+                    {scanHistory.map((scan) => (
+                      <div
+                        key={scan.id}
+                        className="border border-gray-200 dark:border-gray-700 rounded-lg p-3 text-sm"
+                      >
+                        <div className="flex items-center justify-between mb-2">
+                          <span className="font-medium">
+                            {scan.status === 'completed' ? '✓' : scan.status === 'failed' ? '✗' : '⋯'}{' '}
+                            Scan #{scan.id}
+                          </span>
+                          <span
+                            className={`px-2 py-0.5 rounded text-xs ${
+                              scan.status === 'completed'
+                                ? 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400'
+                                : scan.status === 'failed'
+                                  ? 'bg-red-100 text-red-800 dark:bg-red-900/20 dark:text-red-400'
+                                  : 'bg-blue-100 text-blue-800 dark:bg-blue-900/20 dark:text-blue-400'
+                            }`}
+                          >
+                            {scan.status}
+                          </span>
+                        </div>
+                        <div className="grid grid-cols-3 gap-2 text-xs text-gray-600 dark:text-dark-text-secondary">
+                          <div>Files: {scan.total_files}</div>
+                          <div>Policies: {scan.policies_extracted}</div>
+                          <div>Errors: {scan.errors_count}</div>
+                        </div>
+                        {scan.error_message && (
+                          <p className="text-xs text-red-600 dark:text-red-400 mt-2">{scan.error_message}</p>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex justify-end mt-6">
+              <button
+                onClick={() => {
+                  setDetailsModalOpen(false)
+                  setDetailsRepo(null)
+                  setScanHistory([])
+                }}
+                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Edit Modal */}
+      {editModalOpen && editRepo && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-dark-surface rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-xl font-semibold">Edit Repository</h3>
+              <button
+                onClick={() => {
+                  setEditModalOpen(false)
+                  setEditRepo(null)
+                }}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium mb-2">Name</label>
+                <input
+                  type="text"
+                  value={editRepo.name}
+                  onChange={(e) => setEditRepo({ ...editRepo, name: e.target.value })}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium mb-2">Description</label>
+                <textarea
+                  value={editRepo.description || ''}
+                  onChange={(e) => setEditRepo({ ...editRepo, description: e.target.value })}
+                  rows={3}
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800"
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end space-x-3 mt-6">
+              <button
+                onClick={() => {
+                  setEditModalOpen(false)
+                  setEditRepo(null)
+                }}
+                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleSaveEdit}
+                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
+              >
+                Save Changes
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {deleteModalOpen && deleteRepo && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-white dark:bg-dark-surface rounded-lg shadow-xl max-w-md w-full mx-4 p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-xl font-semibold text-red-600 dark:text-red-400">Delete Repository</h3>
+              <button
+                onClick={() => {
+                  setDeleteModalOpen(false)
+                  setDeleteRepo(null)
+                }}
+                className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="space-y-4">
+              <p className="text-gray-700 dark:text-gray-300">
+                Are you sure you want to delete <strong>{deleteRepo.name}</strong>?
+              </p>
+              <p className="text-sm text-red-600 dark:text-red-400">
+                This will permanently delete the repository and all associated policies. This action cannot be undone.
+              </p>
+            </div>
+
+            <div className="flex justify-end space-x-3 mt-6">
+              <button
+                onClick={() => {
+                  setDeleteModalOpen(false)
+                  setDeleteRepo(null)
+                }}
+                className="px-4 py-2 bg-gray-200 dark:bg-gray-700 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirmDelete}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600"
+              >
+                Delete Repository
               </button>
             </div>
           </div>

--- a/prd.json
+++ b/prd.json
@@ -716,7 +716,7 @@
         "Edit repository configuration",
         "Delete repository and associated policies"
       ],
-      "passes": false
+      "passes": true
     },
     {
       "category": "ui",

--- a/progress.txt
+++ b/progress.txt
@@ -1,5 +1,54 @@
 # Progress Log
 
+## 2026-01-09 - Repository Management Interface Complete
+
+### Completed
+- Enhanced RepositoriesPage with full management interface:
+  - Added filtering by repository type (All/Git/Database/Mainframe)
+  - Implemented sorting by name, created date, and last scan date
+  - Added ascending/descending sort order toggle
+  - Display repository count (filtered vs total)
+
+- Repository details modal:
+  - View complete repository information
+  - Display scan history with status, file counts, policy counts, errors
+  - Show repository metadata (name, type, status, created date, source URL)
+  - Fetch scan history from new backend endpoint
+
+- Edit repository modal:
+  - Edit repository name and description
+  - Save changes via PUT /api/v1/repositories/{id}
+  - Refresh repository list after successful update
+
+- Delete repository modal:
+  - Confirmation dialog with warning about permanent deletion
+  - Delete via DELETE /api/v1/repositories/{id}
+  - Cascading deletion of associated policies
+  - Refresh repository list after deletion
+
+- Backend enhancements:
+  - Added GET /api/v1/repositories/{id}/scans endpoint
+  - Returns last 20 scans for a repository ordered by created date
+  - Integrated with existing PUT and DELETE endpoints
+
+- UI/UX improvements:
+  - Added action buttons (View, Edit, Delete) to each repository card
+  - Consistent modal styling with dark mode support
+  - Clear visual feedback for all actions
+  - Icon-based buttons for space efficiency
+
+- Tested:
+  - Backend API endpoints verified via curl (GET scans, PUT update, DELETE)
+  - Docker containers rebuild successfully with changes
+  - Frontend builds without errors
+  - All CRUD operations functional
+
+### User Story Status
+✅ Story: "Repository management interface" - PASSES
+
+### Next Steps
+- Continue with remaining UI tasks (Policy review interface with Monaco editor, Risk visualization dashboard, etc.)
+
 ## 2026-01-08 - Git Repository Integration Complete
 
 ### Completed


### PR DESCRIPTION
Added comprehensive repository management UI:
- Filter repositories by type (Git/Database/Mainframe)
- Sort by name, created date, or last scan date (asc/desc)
- View repository details with scan history
- Edit repository name and description
- Delete repository with confirmation

Backend enhancements:
- Added GET /api/v1/repositories/{id}/scans endpoint
- Returns last 20 scans ordered by created date
- Integrated with existing PUT and DELETE endpoints

UI improvements:
- Three new modals: Details, Edit, Delete
- Icon-based action buttons on each repository card
- Dark mode support throughout
- Responsive filtering and sorting controls
- Repository count display (filtered vs total)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
