### PR TITLE
feat: Evidence validation to prevent AI hallucination

### DIFF
--- a/backend/app/models/policy.py
+++ b/backend/app/models/policy.py
@@ -34,6 +34,16 @@ class SourceType(str, Enum):
     UNKNOWN = "unknown"
 
 
+class ValidationStatus(str, Enum):
+    """Evidence validation status."""
+
+    PENDING = "pending"  # Not yet validated
+    VALID = "valid"  # Evidence matches source file
+    INVALID = "invalid"  # Evidence does not match source file
+    FILE_NOT_FOUND = "file_not_found"  # Source file no longer exists
+    LINE_MISMATCH = "line_mismatch"  # Line numbers out of range
+
+
 class Policy(Base):
     """Policy model for storing extracted authorization policies."""
 
@@ -97,6 +107,11 @@ class Evidence(Base):
 
     # Code snippet
     code_snippet = Column(Text, nullable=False)
+
+    # Validation status
+    validation_status = Column(SAEnum(ValidationStatus), default=ValidationStatus.PENDING, nullable=False)
+    validation_error = Column(Text, nullable=True)  # Details if validation fails
+    validated_at = Column(DateTime(timezone=True), nullable=True)
 
     # Relationship
     policy = relationship("Policy", back_populates="evidence")

--- a/backend/app/schemas/policy.py
+++ b/backend/app/schemas/policy.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.models.policy import PolicyStatus, RiskLevel, SourceType
+from app.models.policy import PolicyStatus, RiskLevel, SourceType, ValidationStatus
 
 
 class EvidenceBase(BaseModel):
@@ -26,6 +26,9 @@ class Evidence(EvidenceBase):
 
     id: int
     policy_id: int
+    validation_status: ValidationStatus = ValidationStatus.PENDING
+    validation_error: str | None = None
+    validated_at: datetime | None = None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/evidence_validation_service.py
+++ b/backend/app/services/evidence_validation_service.py
@@ -1,0 +1,212 @@
+"""Evidence validation service - prevents AI hallucination by verifying evidence matches source files."""
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+
+from app.models.policy import Evidence, ValidationStatus
+
+logger = logging.getLogger(__name__)
+
+
+class EvidenceValidationService:
+    """Service for validating evidence against source files."""
+
+    def __init__(self, db: Session):
+        """Initialize the evidence validation service.
+
+        Args:
+            db: Database session
+        """
+        self.db = db
+
+    def validate_evidence(self, evidence_id: int, repository_path: str) -> dict[str, str]:
+        """Validate a single evidence item against its source file.
+
+        Args:
+            evidence_id: ID of the evidence to validate
+            repository_path: Path to the repository containing the source files
+
+        Returns:
+            Dictionary with validation result
+        """
+        evidence = self.db.query(Evidence).filter(Evidence.id == evidence_id).first()
+        if not evidence:
+            return {"status": "error", "message": f"Evidence {evidence_id} not found"}
+
+        logger.info(f"Validating evidence {evidence_id}: {evidence.file_path}:{evidence.line_start}-{evidence.line_end}")
+
+        # Build absolute file path
+        file_path = Path(repository_path) / evidence.file_path
+        logger.debug(f"Checking file path: {file_path}")
+
+        # Check if file exists
+        if not file_path.exists():
+            logger.warning(f"File not found: {file_path}")
+            evidence.validation_status = ValidationStatus.FILE_NOT_FOUND
+            evidence.validation_error = f"Source file not found: {evidence.file_path}"
+            evidence.validated_at = datetime.now(UTC)
+            self.db.commit()
+            return {
+                "status": "invalid",
+                "validation_status": ValidationStatus.FILE_NOT_FOUND.value,
+                "message": evidence.validation_error,
+            }
+
+        # Read file and extract lines
+        try:
+            with open(file_path, encoding="utf-8", errors="ignore") as f:
+                lines = f.readlines()
+
+            # Check if line numbers are valid
+            if evidence.line_start < 1 or evidence.line_end > len(lines):
+                logger.warning(
+                    f"Line numbers out of range: {evidence.line_start}-{evidence.line_end} (file has {len(lines)} lines)"
+                )
+                evidence.validation_status = ValidationStatus.LINE_MISMATCH
+                evidence.validation_error = (
+                    f"Line numbers {evidence.line_start}-{evidence.line_end} out of range (file has {len(lines)} lines)"
+                )
+                evidence.validated_at = datetime.now(UTC)
+                self.db.commit()
+                return {
+                    "status": "invalid",
+                    "validation_status": ValidationStatus.LINE_MISMATCH.value,
+                    "message": evidence.validation_error,
+                }
+
+            # Extract actual code from file (convert to 0-based indexing)
+            actual_code_lines = lines[evidence.line_start - 1 : evidence.line_end]
+            actual_code = "".join(actual_code_lines).rstrip()
+
+            # Normalize whitespace for comparison
+            stored_snippet = evidence.code_snippet.rstrip()
+            actual_snippet = actual_code.rstrip()
+
+            # Compare code snippets
+            if stored_snippet == actual_snippet:
+                logger.info(f"Evidence {evidence_id} validated successfully")
+                evidence.validation_status = ValidationStatus.VALID
+                evidence.validation_error = None
+                evidence.validated_at = datetime.now(UTC)
+                self.db.commit()
+                return {
+                    "status": "valid",
+                    "validation_status": ValidationStatus.VALID.value,
+                    "message": "Evidence matches source file",
+                }
+            else:
+                # Code doesn't match - possible hallucination or file changed
+                logger.warning(f"Evidence {evidence_id} code mismatch")
+                logger.debug(f"Expected:\n{stored_snippet[:200]}")
+                logger.debug(f"Actual:\n{actual_snippet[:200]}")
+
+                evidence.validation_status = ValidationStatus.INVALID
+                evidence.validation_error = "Code snippet does not match source file (possible hallucination or file changed)"
+                evidence.validated_at = datetime.now(UTC)
+                self.db.commit()
+                return {
+                    "status": "invalid",
+                    "validation_status": ValidationStatus.INVALID.value,
+                    "message": evidence.validation_error,
+                }
+
+        except Exception as e:
+            logger.error(f"Error validating evidence {evidence_id}: {e}", exc_info=True)
+            evidence.validation_status = ValidationStatus.INVALID
+            evidence.validation_error = f"Validation error: {str(e)}"
+            evidence.validated_at = datetime.now(UTC)
+            self.db.commit()
+            return {
+                "status": "error",
+                "validation_status": ValidationStatus.INVALID.value,
+                "message": evidence.validation_error,
+            }
+
+    def validate_policy_evidence(self, policy_id: int, repository_path: str) -> dict[str, int | list]:
+        """Validate all evidence items for a policy.
+
+        Args:
+            policy_id: ID of the policy
+            repository_path: Path to the repository
+
+        Returns:
+            Dictionary with validation summary
+        """
+        from app.models.policy import Policy
+
+        policy = self.db.query(Policy).filter(Policy.id == policy_id).first()
+        if not policy:
+            return {"error": f"Policy {policy_id} not found"}
+
+        results = []
+        valid_count = 0
+        invalid_count = 0
+
+        for evidence in policy.evidence:
+            result = self.validate_evidence(evidence.id, repository_path)
+            results.append(
+                {
+                    "evidence_id": evidence.id,
+                    "file_path": evidence.file_path,
+                    "validation_status": result.get("validation_status"),
+                    "message": result.get("message"),
+                }
+            )
+
+            if result.get("status") == "valid":
+                valid_count += 1
+            else:
+                invalid_count += 1
+
+        logger.info(
+            f"Policy {policy_id} validation complete: {valid_count} valid, {invalid_count} invalid out of {len(policy.evidence)} evidence items"
+        )
+
+        return {
+            "policy_id": policy_id,
+            "total": len(policy.evidence),
+            "valid": valid_count,
+            "invalid": invalid_count,
+            "results": results,
+        }
+
+    def validate_repository_evidence(self, repository_id: int, repository_path: str) -> dict[str, int | list]:
+        """Validate all evidence items for all policies in a repository.
+
+        Args:
+            repository_id: ID of the repository
+            repository_path: Path to the repository
+
+        Returns:
+            Dictionary with validation summary
+        """
+        from app.models.policy import Policy
+
+        policies = self.db.query(Policy).filter(Policy.repository_id == repository_id).all()
+
+        total_evidence = 0
+        valid_count = 0
+        invalid_count = 0
+        policy_results = []
+
+        for policy in policies:
+            policy_result = self.validate_policy_evidence(policy.id, repository_path)
+            policy_results.append(policy_result)
+            total_evidence += policy_result.get("total", 0)
+            valid_count += policy_result.get("valid", 0)
+            invalid_count += policy_result.get("invalid", 0)
+
+        logger.info(
+            f"Repository {repository_id} validation complete: {valid_count} valid, {invalid_count} invalid out of {total_evidence} evidence items across {len(policies)} policies"
+        )
+
+        return {
+            "repository_id": repository_id,
+            "total_policies": len(policies),
+            "total_evidence": total_evidence,
+            "valid": valid_count,
+            "invalid": invalid_count,
+            "policy_results": policy_results,
+        }

--- a/backend/app/services/scanner_service.py
+++ b/backend/app/services/scanner_service.py
@@ -865,6 +865,17 @@ class ScannerService:
 
             self.db.commit()
 
+            # Validate evidence immediately after extraction
+            from app.services.evidence_validation_service import EvidenceValidationService
+            validation_service = EvidenceValidationService(self.db)
+
+            for policy in policies:
+                for evidence in policy.evidence:
+                    try:
+                        validation_service.validate_evidence(evidence.id, repo_path)
+                    except Exception as e:
+                        logger.error(f"Failed to validate evidence {evidence.id}: {e}")
+
             # Apply auto-approval if enabled
             if repo.tenant_id:
                 from app.services.auto_approval_service import AutoApprovalService


### PR DESCRIPTION
## Backend Changes
- Added ValidationStatus enum to policy models (pending, valid, invalid, file_not_found, line_mismatch)
- Created EvidenceValidationService to validate evidence against source files
  - Verifies file existence
  - Checks line number ranges
  - Compares code snippets character-by-character
  - Records validation status, errors, and timestamps
- Updated Evidence model with validation_status, validation_error, validated_at fields
- Updated Evidence schema to include validation fields
- Added validation endpoints:
  - POST /api/v1/policies/evidence/{evidence_id}/validate - validate single evidence
  - POST /api/v1/policies/{policy_id}/validate-evidence - validate all evidence for policy
  - POST /api/v1/repositories/{repository_id}/validate-evidence - validate all evidence for repository
- Updated scanner service to auto-validate evidence immediately after extraction

## Frontend Changes
- Updated Evidence interface to include validation_status, validation_error, validated_at
- Added validation status badges in PolicyDetailModal:
  - Green "Validated" badge with ShieldCheck icon for valid evidence
  - Red "Invalid" badge with AlertTriangle icon for invalid/file_not_found/line_mismatch
  - Amber "Pending" badge with HelpCircle icon for pending validation
- Display validation errors when evidence fails validation
- Added lucide-react icons: AlertTriangle, ShieldCheck, HelpCircle

## Benefits
- Prevents AI hallucination by verifying extracted policies against actual source code
- Detects when evidence no longer matches source files (code changed)
- Provides confidence that policies are based on real, verifiable code
- Automatic validation during scanning ensures quality from the start
- Visual indicators help users quickly identify validated vs invalid evidence

## User Story Completion
✅ Evidence validation - Prevent AI hallucination
- Run policy extraction on repository
- Review extracted policies
- For each policy, verify evidence exists
- Click evidence link to view source code
- Confirm quoted code matches actual file
- Verify line numbers are accurate
- Check that evidence supports extracted policy
- Reject policies without valid evidence

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
