### PR TITLE
feat: Separate test infrastructure from product features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,151 @@
+.PHONY: help install dev docker-up docker-down docker-rebuild test e2e lint lint-backend lint-frontend \
+        damonnator damonnator-test damonnator-infra damonnator-all status clean
+
+##@ General
+
+help: ## Show this help message
+	@echo "Poalo Policy Miner - Makefile Commands"
+	@echo ""
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Installation
+
+install: ## Install all dependencies
+	@echo "Installing backend dependencies..."
+	cd backend && pip install -r requirements.txt
+	@echo "Installing frontend dependencies..."
+	cd frontend && bun install
+	@echo "Installing E2E test dependencies..."
+	cd e2e && pip install -r requirements.txt || echo "⚠️  e2e/ not yet created"
+	@echo "✅ All dependencies installed"
+
+##@ Development
+
+dev: ## Start development servers (frontend + backend)
+	@echo "Starting development servers..."
+	@echo "Frontend: http://localhost:3333"
+	@echo "Backend: http://localhost:7777"
+	@trap 'kill 0' INT; \
+	cd backend && uvicorn app.main:app --reload --host 0.0.0.0 --port 7777 & \
+	cd frontend && bun run dev --port 3333 & \
+	wait
+
+docker-up: ## Start all Docker services
+	@echo "Starting Docker services..."
+	docker-compose up -d
+	@echo "✅ Services started"
+	@echo "Frontend: http://localhost:3333"
+	@echo "Backend: http://localhost:7777"
+	@echo "Prometheus: http://localhost:9090"
+	@echo "Grafana: http://localhost:4000"
+
+docker-down: ## Stop all Docker services
+	@echo "Stopping Docker services..."
+	docker-compose down
+	@echo "✅ Services stopped"
+
+docker-rebuild: ## Rebuild and restart Docker services
+	@echo "Rebuilding Docker services..."
+	docker-compose down
+	docker-compose build
+	docker-compose up -d
+	@echo "✅ Services rebuilt and started"
+
+##@ Testing
+
+test: ## Run backend unit tests
+	@echo "Running backend tests..."
+	cd backend && pytest
+	@echo "✅ Tests passed"
+
+e2e: ## Run E2E tests manually (requires e2e/ infrastructure)
+	@echo "Running E2E tests..."
+	@if [ ! -d "e2e" ]; then \
+		echo "❌ e2e/ directory not found. Run 'make damonnator-infra' first to build test infrastructure."; \
+		exit 1; \
+	fi
+	python3 e2e/e2e_runner.py --test-suite e2e-tests.json --prd prd.json --output test-results.json
+	@echo "✅ E2E tests complete. See test-results.json"
+
+##@ Code Quality
+
+lint: lint-backend lint-frontend ## Run all linters
+
+lint-backend: ## Run backend linter (Ruff)
+	@echo "Linting backend..."
+	cd backend && ruff check .
+	@echo "✅ Backend linting passed"
+
+lint-frontend: ## Run frontend linter (ESLint)
+	@echo "Linting frontend..."
+	cd frontend && bun run lint
+	@echo "✅ Frontend linting passed"
+
+##@ Autonomous Loops
+
+damonnator: ## Run development loop (builds product features from prd.json)
+	@echo "🤖 Starting Damonnator development loop..."
+	@echo "Building product features from prd.json"
+	@echo "Press Ctrl+C to stop"
+	./damonnator.sh
+
+damonnator-test: ## Run testing loop (validates completed features)
+	@echo "🧪 Starting Damonnator testing loop..."
+	@echo "Validating completed features from prd.json"
+	@echo "Press Ctrl+C to stop"
+	@if [ ! -d "e2e" ]; then \
+		echo "❌ e2e/ directory not found. Run 'make damonnator-infra' first to build test infrastructure."; \
+		exit 1; \
+	fi
+	./damonnator_test.sh
+
+damonnator-infra: ## Run infrastructure loop (builds test infrastructure from test-prd.json)
+	@echo "🏗️  Starting Damonnator infrastructure loop..."
+	@echo "Building E2E test infrastructure from test-prd.json"
+	@echo "Press Ctrl+C to stop"
+	./damonnator_infra.sh
+
+damonnator-all: ## Run all loops in parallel (infra + dev + test)
+	@echo "🚀 Starting all Damonnator loops in parallel..."
+	@echo "Infrastructure: builds test framework"
+	@echo "Development: builds product features"
+	@echo "Testing: validates features"
+	@echo "Press Ctrl+C to stop all"
+	@trap 'kill 0' INT; \
+	./damonnator_infra.sh & \
+	./damonnator.sh & \
+	sleep 30 && ./damonnator_test.sh & \
+	wait
+
+##@ Status
+
+status: ## Show service status and PRD progress
+	@echo "=========================================="
+	@echo "📊 Policy Miner Status"
+	@echo "=========================================="
+	@echo ""
+	@echo "🐳 Docker Services:"
+	@docker-compose ps 2>/dev/null || echo "  Services not running (run 'make docker-up')"
+	@echo ""
+	@echo "📋 Product Features (prd.json):"
+	@python3 -c "import json; data=json.load(open('prd.json')); total=len(data['stories']); done=sum(1 for s in data['stories'] if s.get('passes')); print(f'  Total: {total}'); print(f'  Completed: {done} ({done*100//total}%)'); print(f'  Remaining: {total-done}')"
+	@echo ""
+	@echo "🧪 Test Infrastructure (test-prd.json):"
+	@python3 -c "import json; data=json.load(open('test-prd.json')); total=len(data['stories']); done=sum(1 for s in data['stories'] if s.get('passes')); print(f'  Total: {total}'); print(f'  Completed: {done} ({done*100//total}%)'); print(f'  Remaining: {total-done}')" 2>/dev/null || echo "  Not yet started"
+	@echo ""
+	@if [ -f "test-results.json" ]; then \
+		echo "📊 Latest E2E Test Results:"; \
+		python3 -c "import json; data=json.load(open('test-results.json')); s=data['summary']; print(f'  Passed: {s[\"passed\"]}'); print(f'  Failed: {s[\"failed\"]}'); print(f'  Pass Rate: {s[\"pass_rate\"]}%')"; \
+		echo ""; \
+	fi
+
+##@ Cleanup
+
+clean: ## Clean temporary files and caches
+	@echo "Cleaning temporary files..."
+	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete 2>/dev/null || true
+	find . -type d -name ".pytest_cache" -exec rm -rf {} + 2>/dev/null || true
+	find . -type d -name "node_modules" -exec rm -rf {} + 2>/dev/null || true
+	rm -rf e2e/screenshots/*.png 2>/dev/null || true
+	@echo "✅ Cleaned"

--- a/damonnator_infra.sh
+++ b/damonnator_infra.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+# damonnator_infra.sh - Build Test Infrastructure from test-prd.json
+# Usage: ./damonnator_infra.sh [iterations]
+#
+# This script reads test-prd.json and builds the E2E testing infrastructure.
+# It is separate from damonnator.sh to keep concerns separated:
+# - damonnator.sh: builds product features from prd.json
+# - damonnator_infra.sh: builds test infrastructure from test-prd.json
+# - damonnator_test.sh: validates features using the test infrastructure
+
+ITERATIONS=${1:-20}
+REPO="https://github.com/doogie-bigmack/application-security-policy-miner"
+
+echo ""
+echo "=========================================="
+echo "🏗️  Damonnator Infrastructure Builder"
+echo "=========================================="
+echo "Building E2E testing infrastructure from test-prd.json"
+echo "Repo: $REPO"
+echo "Iterations: $ITERATIONS"
+echo ""
+
+for ((i=1; i<=$ITERATIONS; i++)); do
+    echo ""
+    echo "=========================================="
+    echo "Iteration $i of $ITERATIONS"
+    echo "=========================================="
+    echo ""
+
+    # Create temp output file
+    TEMP_OUTPUT=$(mktemp)
+
+    echo "🤖 Starting Claude (this may take 10-30 seconds before output appears)..."
+    echo ""
+
+    # Run claude with heredoc - focuses on test-prd.json instead of prd.json
+    claude --dangerously-skip-permissions -p "@test-prd.json @progress.txt" << 'PROMPT' | tee "$TEMP_OUTPUT"
+You are an autonomous software engineer building E2E testing infrastructure.
+
+## REPO
+https://github.com/doogie-bigmack/application-security-policy-miner
+
+## STACK
+- Frontend: Bun, React, TailwindCSS, TypeScript
+- Backend: FastAPI, SQLAlchemy, PostgreSQL
+- Linting: ESLint/Prettier (frontend), Ruff (backend)
+- Deployment: Docker (use docker-compose for local dev)
+- Testing: Python 3.12, Claude Chrome MCP integration
+
+## START EVERY SESSION
+1. Read the test-prd.json file above - this defines the test infrastructure to build
+2. Read the progress.txt file above - this is what was done recently
+3. Run: git log --oneline -10
+4. Ensure Docker containers are running: docker-compose up -d
+
+## YOUR JOB
+You are building the E2E testing infrastructure, NOT product features.
+
+1. Pick ONE task from test-prd.json that has passes: false
+2. Create a feature branch: git checkout -b test-infra/[task-id]
+3. Implement it following the steps in test-prd.json
+4. Validate it works:
+   - Run linters and fix any errors
+   - Test the code manually (e.g., run e2e_runner.py)
+   - Verify Python imports work correctly
+   - For test scenarios, verify they can execute against localhost:3333
+5. Update test-prd.json - set passes: true for the completed task
+6. Update progress.txt with what you did
+7. Commit: git add -A && git commit -m "test: [description]"
+8. Push branch: git push -u origin test-infra/[task-id]
+9. Create PR and merge to main:
+   - gh pr create --fill --base main
+   - gh pr merge --auto --squash
+10. Return to main: git checkout main && git pull
+
+## CRITICAL GUIDANCE
+- You are building TEST INFRASTRUCTURE, not application features
+- Focus on test-prd.json stories (TEST-001 through TEST-014)
+- Build reusable components: ClaudeChromeExecutor, E2ETestRunner, TestReporter
+- Create test scenarios that can be composed for different flows
+- Ensure all Python code has proper error handling
+- Use Claude's Chrome MCP tools correctly (mcp__claude-in-chrome__*)
+- Test against localhost:3333 (frontend) and localhost:7777 (backend)
+
+## BROWSER AUTOMATION
+When implementing ClaudeChromeExecutor, use these MCP tools:
+- mcp__claude-in-chrome__navigate - navigate to URLs
+- mcp__claude-in-chrome__computer - click elements, take screenshots
+- mcp__claude-in-chrome__form_input - fill form fields
+- mcp__claude-in-chrome__read_page - read page accessibility tree
+- mcp__claude-in-chrome__tabs_context_mcp - get tab context
+
+## RULES
+- Only work on ONE task per iteration
+- Each task gets its own branch and PR
+- Never mark passes: true without validating the code works
+- Never leave broken code - if stuck, revert and document in progress.txt
+- Always commit working code
+- Use docker-compose for all services
+
+## COMPLETION
+When ALL tasks in test-prd.json have passes: true, output exactly: <promise>TEST_INFRA_COMPLETE</promise>
+
+Now start working.
+PROMPT
+
+    # Check if complete
+    if grep -q "<promise>TEST_INFRA_COMPLETE</promise>" "$TEMP_OUTPUT"; then
+        echo ""
+        echo "🎉 Test infrastructure COMPLETE after $i iterations!"
+        rm -f "$TEMP_OUTPUT"
+        osascript -e 'display notification "Test infrastructure is ready!" with title "Damonnator Infra" sound name "Glass"'
+        exit 0
+    fi
+
+    # Clean up temp file
+    rm -f "$TEMP_OUTPUT"
+
+done
+
+echo ""
+echo "Finished $ITERATIONS iterations"
+osascript -e 'display notification "Damonnator Infra completed all iterations" with title "Damonnator Infra" sound name "Ping"'

--- a/progress.txt
+++ b/progress.txt
@@ -3437,3 +3437,57 @@ Requirements met:
 - Fix SecretDetectionLog relationship issue in Repository model
 - Continue with remaining incomplete stories from PRD
 
+[2026-01-09 16:15] 🏗️  Separated Test Infrastructure from Product Features
+
+### Problem
+User correctly identified that prd.json (product features) should not be muddled with test infrastructure tasks. Test infrastructure is operational/meta work, not product work.
+
+### Solution
+Created separate test-prd.json file to define test infrastructure build tasks, keeping concerns separated:
+
+**Three autonomous loops, three PRD files:**
+1. **damonnator.sh** → reads **prd.json** → builds product features
+2. **damonnator_infra.sh** → reads **test-prd.json** → builds test infrastructure  
+3. **damonnator_test.sh** → reads **prd.json** + e2e-tests.json → validates product features
+
+### Files Created
+
+**test-prd.json**
+- 14 stories (TEST-001 through TEST-014)
+- Defines tasks to build E2E testing infrastructure
+- Maps to GitHub Issue #53
+- All stories have passes: false (ready to build)
+
+**damonnator_infra.sh**
+- New autonomous loop script
+- Reads test-prd.json to build test infrastructure
+- Creates test-infra/* feature branches
+- Completes when all TEST-* stories have passes: true
+- Success signal: <promise>TEST_INFRA_COMPLETE</promise>
+
+**Makefile**
+- Comprehensive command orchestration
+- Key targets:
+  - `make damonnator` - build product features
+  - `make damonnator-infra` - build test infrastructure
+  - `make damonnator-test` - validate features
+  - `make damonnator-all` - run all three loops in parallel
+  - `make status` - show progress for both PRDs
+  - `make e2e` - run E2E tests manually
+
+### What Gets Built
+
+When you run `./damonnator_infra.sh`, it will implement:
+- e2e/ directory with Python test framework
+- e2e_runner.py (orchestrator)
+- test_executor.py (Claude Chrome wrapper)
+- test_reporter.py (results generator)
+- e2e-tests.json (5 critical tests)
+- test-results.json schema
+- 5 reusable test scenarios
+
+### Next Steps
+Run: `./damonnator_infra.sh` or `make damonnator-infra`
+
+This will build out the entire E2E testing infrastructure from test-prd.json.
+

--- a/test-prd.json
+++ b/test-prd.json
@@ -1,0 +1,355 @@
+{
+  "metadata": {
+    "name": "E2E Testing Infrastructure PRD",
+    "description": "Product requirements for building the automated E2E testing system that validates Policy Miner features",
+    "version": "1.0",
+    "created": "2026-01-09",
+    "github_issue": "https://github.com/doogie-bigmack/application-security-policy-miner/issues/53"
+  },
+  "stories": [
+    {
+      "id": "TEST-001",
+      "category": "infrastructure",
+      "priority": "critical",
+      "description": "Create e2e directory structure and Python dependencies",
+      "steps": [
+        "Create e2e/ directory in project root",
+        "Create e2e/__init__.py for Python package",
+        "Create e2e/requirements.txt with dependencies: anthropic, requests, jq (via subprocess)",
+        "Create e2e/README.md explaining directory structure",
+        "Verify Python 3.12 compatibility"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "e2e/ directory exists",
+        "requirements.txt can be installed with pip",
+        "All dependencies resolve without conflicts"
+      ]
+    },
+    {
+      "id": "TEST-002",
+      "category": "infrastructure",
+      "priority": "critical",
+      "description": "Implement ClaudeChromeExecutor wrapper for browser automation",
+      "steps": [
+        "Create e2e/test_executor.py",
+        "Implement ClaudeChromeExecutor class",
+        "Add navigate(url) method wrapping mcp__claude-in-chrome__navigate",
+        "Add click(selector) method wrapping mcp__claude-in-chrome__computer",
+        "Add fill_input(selector, value) method wrapping mcp__claude-in-chrome__form_input",
+        "Add assert_visible(selector, timeout_ms) method wrapping mcp__claude-in-chrome__read_page",
+        "Add take_screenshot(filename) method wrapping mcp__claude-in-chrome__computer screenshot",
+        "Add wait_for_element(selector, timeout_ms) method",
+        "Add get_page_text() method for debugging",
+        "Add error handling and retry logic",
+        "Create unit tests for each method"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "ClaudeChromeExecutor can navigate to localhost:3333",
+        "Can click elements by selector",
+        "Can fill form inputs",
+        "Can assert element visibility",
+        "Screenshots save to e2e/screenshots/ on failure"
+      ]
+    },
+    {
+      "id": "TEST-003",
+      "category": "infrastructure",
+      "priority": "critical",
+      "description": "Create e2e-tests.json schema and 5 critical test definitions",
+      "steps": [
+        "Create e2e-tests.json in project root",
+        "Define schema version and test_suites structure",
+        "Create test suite: repository_management",
+        "Add test: test_add_github_repository (maps to prd.json FUNC-001)",
+        "Add test: test_scan_repository (maps to prd.json AI rule mining)",
+        "Add test: test_view_policies (maps to prd.json policy viewing)",
+        "Add test: test_add_pbac_provider (maps to prd.json PBAC integration)",
+        "Add test: test_provision_policy (maps to prd.json policy provisioning)",
+        "Define test steps with actions: navigate, click, fill, wait_for_element, assert_element_visible",
+        "Add expected_outcomes for each test",
+        "Add cleanup steps for test data",
+        "Add prerequisites (services, test_data) for each test",
+        "Validate JSON syntax"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "e2e-tests.json is valid JSON",
+        "Contains 5 test definitions",
+        "Each test maps to a prd.json story ID",
+        "All required fields present: test_id, prd_story_id, name, priority, steps"
+      ]
+    },
+    {
+      "id": "TEST-004",
+      "category": "infrastructure",
+      "priority": "critical",
+      "description": "Create test-results.json schema and TestReporter implementation",
+      "steps": [
+        "Create example test-results.json schema in docs or comments",
+        "Create e2e/test_reporter.py",
+        "Implement TestReporter class",
+        "Add generate_report() method that creates test-results.json",
+        "Include test run metadata: test_run_id, started_at, completed_at, duration_seconds, trigger",
+        "Include summary: total_tests, passed, failed, skipped, pass_rate",
+        "Include detailed test_results array with status, duration, error details",
+        "Add error diagnostics: type, message, step_index, screenshot, console_errors",
+        "Add recommendations array using AI analysis of failures",
+        "Add coverage_analysis: prd_stories_tested, prd_stories_total, coverage_percentage",
+        "Validate JSON output"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "test-results.json generated after test run",
+        "Contains all required fields per schema",
+        "Pass/fail status accurately reflects test outcomes",
+        "Screenshots referenced in error objects exist in e2e/screenshots/",
+        "Recommendations provide actionable debugging guidance"
+      ]
+    },
+    {
+      "id": "TEST-005",
+      "category": "infrastructure",
+      "priority": "critical",
+      "description": "Implement E2ETestRunner orchestrator",
+      "steps": [
+        "Create e2e/e2e_runner.py",
+        "Implement E2ETestRunner class",
+        "Add load_test_suite(path) method to parse e2e-tests.json",
+        "Add load_prd(path) method to parse prd.json",
+        "Add run_tests(filter_priority, filter_story_ids) method",
+        "Implement test execution loop using ClaudeChromeExecutor",
+        "Add error handling and screenshot capture on failure",
+        "Add retry logic for flaky tests (1 retry max)",
+        "Call TestReporter to generate test-results.json",
+        "Add CLI argument parsing: --test-suite, --prd, --output, --filter-priority, --filter-story-id",
+        "Add verbose logging to console"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "Can execute: python3 e2e/e2e_runner.py --test-suite e2e-tests.json --prd prd.json",
+        "Runs all 5 critical tests",
+        "Generates test-results.json",
+        "Exits with code 0 if all pass, code 1 if any fail",
+        "Logs test progress to console"
+      ]
+    },
+    {
+      "id": "TEST-006",
+      "category": "integration",
+      "priority": "high",
+      "description": "Wire damonnator_test.sh to execute E2E runner",
+      "steps": [
+        "Review existing damonnator_test.sh (already created in PR #54)",
+        "Verify it reads @e2e-tests.json and @test-results.json",
+        "Ensure it calls e2e/e2e_runner.py correctly",
+        "Add logic to parse test-results.json and update prd.json test_metadata",
+        "Test manual execution of damonnator_test.sh",
+        "Verify it creates GitHub issues on test failures"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "./damonnator_test.sh 1 executes successfully",
+        "Runs E2E tests via e2e_runner.py",
+        "Updates prd.json with test results",
+        "Creates GitHub issue if tests fail"
+      ]
+    },
+    {
+      "id": "TEST-007",
+      "category": "scenarios",
+      "priority": "high",
+      "description": "Create reusable test scenario: Add GitHub Repository",
+      "steps": [
+        "Create e2e/scenarios/ directory",
+        "Create e2e/scenarios/repository_crud.py",
+        "Implement add_github_repository() function",
+        "Navigate to http://localhost:3333/repositories",
+        "Click 'Add Repository' button",
+        "Click 'GitHub' integration option",
+        "Fill in test token (from environment variable GITHUB_TEST_TOKEN)",
+        "Click 'Connect' button",
+        "Assert success message appears",
+        "Assert repository appears in list",
+        "Return repository ID for cleanup",
+        "Add cleanup function to delete test repository"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "Function successfully adds GitHub repository",
+        "Returns repository ID",
+        "Cleanup function removes test data"
+      ]
+    },
+    {
+      "id": "TEST-008",
+      "category": "scenarios",
+      "priority": "high",
+      "description": "Create reusable test scenario: Scan Repository",
+      "steps": [
+        "Create scan_repository() function in e2e/scenarios/repository_crud.py",
+        "Accept repository_id as parameter",
+        "Navigate to repository detail page",
+        "Click 'Start Scan' button",
+        "Wait for scan to complete (check for status change)",
+        "Assert scan completes successfully",
+        "Assert policies were extracted (count > 0)",
+        "Return scan results"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "Function triggers scan successfully",
+        "Waits for scan completion",
+        "Validates policies extracted"
+      ]
+    },
+    {
+      "id": "TEST-009",
+      "category": "scenarios",
+      "priority": "medium",
+      "description": "Create reusable test scenario: View and Filter Policies",
+      "steps": [
+        "Create e2e/scenarios/policy_viewing.py",
+        "Implement view_policies() function",
+        "Navigate to policies page",
+        "Assert policies table is visible",
+        "Assert columns: Subject (Who), Resource (What), Action (How), Conditions (When), Evidence",
+        "Test filtering by subject",
+        "Test filtering by resource",
+        "Test sorting by different columns",
+        "Click a policy row to view details",
+        "Assert detail view shows code evidence"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "Can navigate to policies page",
+        "Can filter and sort policies",
+        "Can view policy details with evidence"
+      ]
+    },
+    {
+      "id": "TEST-010",
+      "category": "scenarios",
+      "priority": "medium",
+      "description": "Create reusable test scenario: Add PBAC Provider",
+      "steps": [
+        "Create e2e/scenarios/provisioning_flow.py",
+        "Implement add_pbac_provider() function",
+        "Navigate to PBAC providers page",
+        "Click 'Add Provider' button",
+        "Select provider type (OPA/AWS/Axiomatics)",
+        "Fill in provider configuration (endpoint, credentials)",
+        "Click 'Test Connection' button",
+        "Assert connection test succeeds",
+        "Click 'Save' button",
+        "Assert provider appears in list",
+        "Return provider ID for cleanup"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "Can add PBAC provider",
+        "Connection test validates successfully",
+        "Provider saved and visible in list"
+      ]
+    },
+    {
+      "id": "TEST-011",
+      "category": "scenarios",
+      "priority": "medium",
+      "description": "Create reusable test scenario: Provision Policy to PBAC",
+      "steps": [
+        "Create provision_policy() function in e2e/scenarios/provisioning_flow.py",
+        "Accept policy_id and provider_id as parameters",
+        "Navigate to policy detail page",
+        "Click 'Provision' button",
+        "Select target PBAC provider from dropdown",
+        "Select target format (OPA Rego / AWS Cedar / Axiomatics ALFA)",
+        "Click 'Provision' button",
+        "Wait for provisioning to complete",
+        "Assert provisioning status shows 'Success'",
+        "Assert provisioned policy appears in provider's policy list"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "Can provision policy to PBAC provider",
+        "Provisioning completes successfully",
+        "Policy visible in target PBAC system"
+      ]
+    },
+    {
+      "id": "TEST-012",
+      "category": "validation",
+      "priority": "critical",
+      "description": "End-to-end validation: Run full test suite and verify feedback quality",
+      "steps": [
+        "Run: python3 e2e/e2e_runner.py --test-suite e2e-tests.json --prd prd.json --output test-results.json",
+        "Verify all 5 critical tests execute",
+        "Check test-results.json is generated",
+        "Verify summary section shows correct pass/fail counts",
+        "For any failed tests, verify error diagnostics include: type, message, step_index, screenshot path, console_errors",
+        "Verify screenshots exist in e2e/screenshots/ for failed tests",
+        "Verify recommendations array provides actionable debugging steps",
+        "Run a deliberate failure test (break a selector) to validate failure reporting",
+        "Verify failure report includes: root cause analysis, code locations to check, recommended fixes"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "Full test suite runs to completion",
+        "test-results.json contains all required fields",
+        "Failure scenarios generate rich diagnostics",
+        "Recommendations are actionable and accurate",
+        "Screenshots captured on failure"
+      ]
+    },
+    {
+      "id": "TEST-013",
+      "category": "documentation",
+      "priority": "medium",
+      "description": "Update TESTING.md with actual usage examples",
+      "steps": [
+        "Review existing TESTING.md (created in PR #54)",
+        "Add section: 'Running E2E Tests Manually'",
+        "Document: python3 e2e/e2e_runner.py command with all options",
+        "Add section: 'Understanding Test Results'",
+        "Document test-results.json schema with examples",
+        "Add section: 'Debugging Failed Tests'",
+        "Include examples of using screenshots and error diagnostics",
+        "Add section: 'Writing New Test Scenarios'",
+        "Document e2e-tests.json schema with example test definition",
+        "Add troubleshooting guide for common issues"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "TESTING.md updated with manual testing guide",
+        "Includes command examples with output",
+        "Documents schemas with examples",
+        "Provides debugging guidance"
+      ]
+    },
+    {
+      "id": "TEST-014",
+      "category": "integration",
+      "priority": "high",
+      "description": "Integrate with Makefile and validate end-to-end flow",
+      "steps": [
+        "Verify Makefile targets exist (created in PR #54): make e2e, make damonnator-test",
+        "Test: make e2e (should run e2e_runner.py directly)",
+        "Test: make damonnator-test (should run damonnator_test.sh loop)",
+        "Verify: make status shows test results summary",
+        "Test full flow: make docker-up && make e2e",
+        "Verify services start and tests execute",
+        "Test deliberate failure to verify error reporting",
+        "Verify GitHub issue creation on test failure",
+        "Document any issues found and fix them"
+      ],
+      "passes": false,
+      "acceptance_criteria": [
+        "make e2e runs successfully",
+        "make damonnator-test executes testing loop",
+        "make status shows test metrics",
+        "Full flow works end-to-end"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Created a clean separation between product feature development and test infrastructure development by introducing test-prd.json to define test infrastructure build tasks.

## Problem

Previously attempted to add E2E testing tasks to prd.json, which would muddle product features with operational/meta tasks. User correctly identified that test infrastructure should be tracked separately.

## Solution

Three Autonomous Loops, Three PRD Files:
1. damonnator.sh → prd.json → builds product features
2. damonnator_infra.sh → test-prd.json → builds test infrastructure  
3. damonnator_test.sh → prd.json + e2e-tests.json → validates features

## Files Created

- test-prd.json: 14 stories (TEST-001 to TEST-014)
- damonnator_infra.sh: Autonomous loop to build test infrastructure
- Makefile: Command orchestration with targets for all operations

## Usage

make damonnator-infra   # Build test infrastructure
make damonnator         # Build product features
make damonnator-test    # Validate features
make damonnator-all     # Run all three in parallel
make status             # Show progress

🤖 Generated with Claude Code